### PR TITLE
P_R3B9[Bug]  Баг функции `Exit` (Закрытие программы через крестик)

### DIFF
--- a/EditorTeam/mainwindow.cpp
+++ b/EditorTeam/mainwindow.cpp
@@ -338,6 +338,11 @@ void MainWindow::retranslateGUI()
     settingsKeeper->retranslateGUI();
 }
 
+void MainWindow::closeEvent(QCloseEvent *)
+{
+    onExit();
+}
+
 void MainWindow::changeFileMenuAccess(const QString &winTitle,
                                       bool hideTextEdit, bool enableSaveAs,
                                       bool enableClose)

--- a/EditorTeam/mainwindow.h
+++ b/EditorTeam/mainwindow.h
@@ -81,6 +81,9 @@ class MainWindow : public QMainWindow
     void retranslateMenus();
     void retranslateGUI();
 
+    //Функция для закрытия программы через крестик
+    void closeEvent(QCloseEvent *) override;
+
     /*! GubaydullinRG Переменная, хранящая скопированный функцией
      * onCopyTextFormat() формат выделенного фрагмента текста для передачи его в
      * onApplyTextFormat() */


### PR DESCRIPTION
Добавил событие, которое вызывает функцию Exit() перед тем как закрыть файл через крестик приложения